### PR TITLE
Adding 'shared' target to create libmurmur.so

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,5 +8,9 @@ tests: test.o murmur3.o
 	$(CC) $^ -o $@
 	./tests
 
+shared: murmur3.c murmur3.h
+	$(CC) -fPIC -O3 -c murmur3.c
+	$(CC) -shared -Wl,--export-dynamic murmur3.o -o libmurmur3.so
+
 clean:
-	rm -rf example *.o
+	rm -rf example *.o *.so


### PR DESCRIPTION
Adding this extra make target was useful for me...thought I'd share it.

I'm sure there's probably a better/more elegant way to do this, so I'm open to feedback.
